### PR TITLE
Word wrap

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ var url = document.getElementById("url_search")
 const form = document.getElementById("search-form")
 
 function startSearch() {
-    var url_heading = document.createElement("h3");
+    var url_heading = document.getElementById("form_url");
     var node = document.createTextNode(bar.value);
     url_heading.appendChild(node);
     var url_div = document.getElementById("form_url");

--- a/style.css
+++ b/style.css
@@ -135,7 +135,7 @@ img {
 }
 
 #form_url {
-    width: 60%;
+    width: 470px;
     text-align: center;
     overflow-wrap: break-word;
     word-wrap: break-word;

--- a/style.css
+++ b/style.css
@@ -61,13 +61,6 @@ body {
     padding-bottom: 10px;
 }
 
-#form_url {
-    text-align: center;
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    /* font-size: 3em; */
-}
-
 /* Trying to fix the tiled background image */
 .body_text {
     /* width: 700px; */
@@ -139,4 +132,12 @@ h1 {
 img {
     width: 250px;
     height: 250px;
+}
+
+#form_url {
+    width: 60%;
+    text-align: center;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    /* font-size: 3em; */
 }


### PR DESCRIPTION
I solved the url overflow issue. All I had to do was set the width of the div to 470px, and then set the overflow-wrap and word-wrap attributes both to "word-break". It's not quite a permanent fix, and will likely have to be re-worked if the modal size changes. But for now, the modal is a static width, and the url stays within that width.